### PR TITLE
providers.tf: Stop provider aws overriding external provider aws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.3 (Unreleased)
+
+BUG FIXES:
+
+providers.tf: provider aws overrides external provider aws (#1)
+
 ## Release Version: 0.0.2
 
 BACKWARDS INCOMPATIBILITIES / NOTES:
@@ -8,7 +14,7 @@ NEW FEATURES:
 
 * Multiple roles can be added to the IDP
 
-IMPROVEMENTS:
+ENHANCEMENTS:
 
 *
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 
-providers.tf: provider aws overrides external provider aws (#1)
+providers.tf: provider aws overrides external provider aws ([#4](https://github.com/zoitech/terraform-aws-saml/issues/4))
 
 ## Release Version: 0.0.2
 

--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-    region = "${var.aws_region}"
-}


### PR DESCRIPTION
Closes #4 

Providers.tf file removed. The AWS provider should be configured externally from the module.